### PR TITLE
Potential fix for code scanning alert no. 65: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -19,6 +19,10 @@ class ErrorWithParent extends Error {
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    if (typeof criteria !== 'string') {
+      res.status(400).send('Bad request')
+      return
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/foglirodrigo-arch/juice-shop-ada-1497/security/code-scanning/65](https://github.com/foglirodrigo-arch/juice-shop-ada-1497/security/code-scanning/65)

To fix this vulnerability, always check that `criteria` is a string before using it as a string or building a SQL query. The best approach is to add a type check after extracting the value from `req.query.q`. If it is not a string, either reject the request (the strictest and safest option), or coerce it to a string in a deterministic and safe way (e.g., take the first array element, or join with a safe separator, although this may behave unexpectedly for some users). The safest and most defensive fix is to return a 400 error when a parameter type is not string. 

In this specific region, edit lines after the extraction of `criteria` (line 21) to:
- Check whether `criteria` is a string.
- If not, return a 400 error using the Express response.
- Otherwise, proceed as usual.

No additional methods are required; a simple type check (`typeof criteria !== 'string'`) plus early abort suffices. No extra imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
