### PR TITLE
Potential fix for code scanning alert no. 64: Type confusion through parameter tampering

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -133,6 +133,9 @@ export const redirectAllowlist = new Set([
 ])
 
 export const isRedirectAllowed = (url: string) => {
+  if (typeof url !== 'string') {
+    return false
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge


### PR DESCRIPTION
Potential fix for [https://github.com/foglirodrigo-arch/juice-shop-ada-1497/security/code-scanning/64](https://github.com/foglirodrigo-arch/juice-shop-ada-1497/security/code-scanning/64)

To fix the problem, we must ensure that the `url` parameter handed to `isRedirectAllowed` is always a string, so that string methods are used as intended and type confusion is avoided. The most robust fix is to check the runtime type of the parameter before performing any string operations. If the type is not a string (for example, if it is an array), we should immediately reject the input as invalid.

There are two places where this could be enforced:
1. At the entry to `isRedirectAllowed` in `lib/insecurity.ts`—this ensures all usages are safe.
2. Or in `performRedirect` in `routes/redirect.ts`—this ensures only the usage in that route is safe.

The best fix is to add a runtime type check at the beginning of the `isRedirectAllowed` function in `lib/insecurity.ts`. If the type of `url` is not 'string', then the function should return `false` immediately, refusing the redirect. This way, future uses of `isRedirectAllowed` are protected, and downstream logic only executes when the parameter is actually a string.

*No new imports are needed. The fix only involves an additional type check at the beginning of isRedirectAllowed in lib/insecurity.ts.*

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
